### PR TITLE
Stronger password for spring-batch-admin

### DIFF
--- a/mlJobRepo/src/main/java/com/marklogic/spring/batch/MarkLogicSimpleJobRepositoryConfig.java
+++ b/mlJobRepo/src/main/java/com/marklogic/spring/batch/MarkLogicSimpleJobRepositoryConfig.java
@@ -81,7 +81,7 @@ public class MarkLogicSimpleJobRepositoryConfig {
     public List<User> getUsers() {
         User springBatchAdmin = api.user("spring-batch-admin");
         springBatchAdmin.setDescription("Admin user for Spring Batch application");
-        springBatchAdmin.setPassword("password");
+        springBatchAdmin.setPassword("passworD_123#@");
         springBatchAdmin.addRole("spring-batch-admin");
 
         List<User> users = new ArrayList<User>();


### PR DESCRIPTION
Change the password from "password" to something stronger because
sec:create-user was failing with SEC-REJECTEDPWD "Password is too weak"